### PR TITLE
update api url

### DIFF
--- a/lib/printful_client.rb
+++ b/lib/printful_client.rb
@@ -13,7 +13,7 @@ require 'uri'
 
 module PrintfulClientModule
 
-	API_URL = 'https://api.theprintful.com/'
+	API_URL = 'https://api.printful.com/'
 	USER_AGENT = 'Printful API Ruby Library 1.0'
 
     @api_key


### PR DESCRIPTION
api.theprintful.com has been discontinued and no longer returns results. The working API URL is https://api.printful.com